### PR TITLE
switch to streams2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 var rimraf = require('rimraf');
-var es = require('event-stream');
+var through = require('through2').obj;
 var gutil = require('gulp-util');
 var path = require('path');
 
 module.exports = function (options) {
-  return es.map(function (file, cb) {
+  return through(function (file, _, cb) {
     // Paths are resolved by gulp
     var filepath = file.path;
     var cwd = file.cwd;

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "rimraf": "~2.2.6",
-    "event-stream": "~3.1.0",
-    "gulp-util": "~2.2.12"
+    "gulp-util": "~2.2.12",
+    "through2": "^0.4.2"
   },
   "devDependencies": {
     "mocha": "~1.17.0",

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 var clean = require('./');
 var expect = require('chai').expect;
-
+function noop() {}
 describe('gulp-clean plugin', function () {
 
   var cwd = process.cwd();
@@ -35,6 +35,7 @@ describe('gulp-clean plugin', function () {
     var stream = clean();
     var content = 'testing';
     fs.writeFile('tmp/test.js', content, function () {
+      stream.on('data', noop);
       stream.on('end', function () {
         fs.exists('tmp/test.js', function (exists) {
           expect(exists).to.be.false;
@@ -69,7 +70,7 @@ describe('gulp-clean plugin', function () {
         base: cwd + '/tmp/',
         path: cwd + '/tmp/test/'
       }));
-
+      stream.on('data', noop);
       stream.end();
     });
   });
@@ -87,7 +88,7 @@ describe('gulp-clean plugin', function () {
           });
         });
       });
-
+      stream.on('data', noop);
       stream.write(new gutil.File({
         cwd: cwd,
         base: cwd + '/tmp',
@@ -107,7 +108,7 @@ describe('gulp-clean plugin', function () {
         done();
       });
     });
-
+    stream.on('data', noop);
     stream.write(new gutil.File({
       cwd: cwd,
       path: cwd
@@ -127,7 +128,7 @@ describe('gulp-clean plugin', function () {
         done();
       });
     });
-
+    stream.on('data', noop);
     stream.write(new gutil.File({
       cwd: path.resolve(cwd),
       path: path.resolve(cwd + '/../secrets/')
@@ -140,7 +141,7 @@ describe('gulp-clean plugin', function () {
     var stream = clean();
 
     if (!fs.existsSync('../gulp-cleanTemp')) { fs.mkdirSync('../gulp-cleanTemp'); }
-
+    stream.on('data', noop);
     stream.on('end', function () {
       fs.exists('../gulp-cleanTemp', function (exists) {
         expect(exists).to.be.true;
@@ -162,7 +163,7 @@ describe('gulp-clean plugin', function () {
     var stream = clean({force: true});
 
     if (!fs.existsSync('../gulp-cleanTemp')) { fs.mkdirSync('../gulp-cleanTemp'); }
-
+    stream.on('data', noop);
     stream.on('end', function () {
       fs.exists('../gulp-cleanTemp', function (exists) {
         expect(exists).to.be.false;


### PR DESCRIPTION
this was causing a race condition when using gulp.clean as it emits 'end' before all files are actually gone, had to add some stuff to the tests as you were listening for end without listening for data.
