### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,5 @@
   "engines": {
     "node": ">=0.9"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/