### PR TITLE
Link directly to information on `del` module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-## Deprecated use [gulp-rimraf](https://github.com/robrich/gulp-rimraf) instead!
-
-
+## Deprecated use [del](https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md) instead!
 
 # [gulp](https://github.com/wearefractal/gulp)-clean [![Build Status](https://secure.travis-ci.org/peter-vilja/gulp-clean.png?branch=master)](https://travis-ci.org/peter-vilja/gulp-clean) [![NPM version](https://badge.fury.io/js/gulp-clean.png)](http://badge.fury.io/js/gulp-clean)
 


### PR DESCRIPTION
Currently, you're linking to https://github.com/robrich/gulp-rimraf , which is also deprecated.  `gulp-rimraf` then directs users to https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md